### PR TITLE
feat: desktop rewrite via pre_llm_call context injection (works without pre_user_message hook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,13 @@ git clone https://github.com/Sahil-SS9/hermes-multichannel-prompt-optimizer ~/.h
 hermes plugins enable prompt-optimizer
 ```
 
-Run the test suite:
+Run the test suite (from a directory *outside* the plugin — its hyphenated
+name is not a valid Python package identifier, which breaks pytest's
+package-root collection when the plugin dir is the rootdir):
 
 ```bash
-cd /path/to/hermes-agent
-venv/bin/pytest tests/plugins/test_prompt_optimizer_plugin.py -v
+cd /tmp && /path/to/hermes-agent/venv/bin/python -m pytest \
+    ~/.hermes/plugins/prompt-optimizer/tests/test_prompt_optimizer_plugin.py -v
 ```
 
 PRs welcome. Please include tests for any new hook semantics or scoring changes.

--- a/__init__.py
+++ b/__init__.py
@@ -606,12 +606,35 @@ def get_tui_preview(session_key: str, text: str, model: str = "",
 # Plugin registration
 # ---------------------------------------------------------------------------
 
+def _hook_supported(name: str) -> bool:
+    """True if the running Hermes core knows this hook name.
+
+    Hermes cores before upstream PR #29526 (NousResearch/hermes-agent)
+    lack ``pre_user_message``; registering it produces a startup warning and
+    a callback that never fires. The import is wrapped so a renamed or
+    removed core constant can never break plugin load — fall back to
+    optimistic registration (previous behaviour) if we can't introspect.
+    """
+    try:
+        from hermes_cli.plugins import VALID_HOOKS
+        return name in VALID_HOOKS
+    except Exception:
+        return True
+
+
 def register(ctx) -> None:
     global _ctx
     _ctx = ctx
     logger.info("prompt-optimizer: initializing")
     ctx.register_hook("pre_gateway_dispatch", _on_pre_gateway_dispatch)
-    ctx.register_hook("pre_user_message", _on_pre_user_message)
+    if _hook_supported("pre_user_message"):
+        ctx.register_hook("pre_user_message", _on_pre_user_message)
+    else:
+        logger.info(
+            "prompt-optimizer: 'pre_user_message' hook unavailable in this "
+            "Hermes build (upstream PR #29526 not merged) — CLI/TUI rewrite "
+            "disabled; gateway rewrite stays active via pre_gateway_dispatch"
+        )
     ctx.register_hook("transform_llm_output", _on_transform_llm_output)
     ctx.register_command(
         "prompt-optimizer", handler=_handle_prompt_optimizer,

--- a/__init__.py
+++ b/__init__.py
@@ -157,12 +157,25 @@ def _on_pre_gateway_dispatch(event=None, gateway=None, session_store=None, **kw)
         return None
     stripped = original.strip()
 
+    # Interactive approval replies ("y"/"n" on the same session) are short
+    # by nature — resolve the pending-approval state BEFORE the short-message
+    # fast-path so a one-word approval is never swallowed by it.
+    session_id = ""
+    if session_store is not None:
+        session_id = getattr(session_store, "session_id", "") or ""
+    sid = session_id or "unknown"
+    pending_approval = False
+    if mode == "interactive":
+        with _pending_lock:
+            pending_approval = sid in _pending_approvals
+
     if any(stripped.startswith(p) for p in BYPASS_PREFIXES):
         return None
 
-    # Short prompts (< 5 words or < 35 chars) do not need LLM rewriting
+    # Short prompts (< 5 words or < 35 chars) do not need LLM rewriting —
+    # except interactive approval replies, which are handled above.
     words = stripped.split()
-    if len(words) < 5 or len(stripped) < 35:
+    if (len(words) < 5 or len(stripped) < 35) and not pending_approval:
         logger.info("prompt-optimizer: skipped — short message (%d words)", len(words))
         return None
 

--- a/__init__.py
+++ b/__init__.py
@@ -8,10 +8,14 @@ Wires four behaviours:
 
 2. ``pre_user_message`` hook — intercepts CLI/TUI messages before agent sees them.
 
-3. ``transform_llm_output`` hook — appends a lightweight inline badge to
+3. ``pre_llm_call`` hook — desktop context-injection path: injects the
+   optimized prompt as guidance context on every platform (works on builds
+   lacking ``pre_user_message``; records mode="context", quality-only badge).
+
+4. ``transform_llm_output`` hook — appends a lightweight inline badge to
    every assistant response when a rewrite occurred this turn.
 
-4. ``/prompt-stats`` and ``/prompt-optimizer`` slash commands.
+5. ``/prompt-stats`` and ``/prompt-optimizer`` slash commands.
 
 Dual mode:
   auto        — silent rewrite, no prompt
@@ -81,6 +85,12 @@ _mode_lock = threading.Lock()
 # Per-session rewrite state (session_id → RewriteRecord)
 _session_rewrites: Dict[str, RewriteRecord] = {}
 _rewrite_lock = threading.Lock()
+
+# Context-mode quality badges (session_id → (quality_before, quality_after)).
+# Separate from _session_rewrites because context injection does NOT save
+# tokens (original + optimized both go on the wire) — the badge must not
+# claim a token saving it didn't produce.
+_context_badges: Dict[str, Tuple[float, float]] = {}
 
 # Interactive mode pending approvals (session_id → (record, timestamp))
 _pending_approvals: Dict[str, Tuple[RewriteRecord, float]] = {}
@@ -444,12 +454,117 @@ def _cli_interactive_approval(sid, record):
     return {"action": "skip", "reason": "awaiting_prompt_optimizer_approval"}
 
 
+# ---------------------------------------------------------------------------
+# Desktop hook (pre_llm_call context injection)
+# ---------------------------------------------------------------------------
+#
+# Hermes v0.20.0 has no pre_user_message hook (upstream PR #29526 closed
+# unmerged), so desktop/CLI messages cannot be replaced before the agent
+# sees them. pre_llm_call is the closest hook that fires on desktop turns:
+# it is called once per turn with the user message, and its return value is
+# injected as CONTEXT appended to that message (API-bound only, never
+# persisted in history — turn_context.py composes it into api_content).
+#
+# This is a guidance rewrite, not a replacement: the model sees the original
+# plus an "optimized version" directive. Tokens therefore go UP slightly
+# (original + optimized both sent), so metrics are recorded with
+# mode="context" and the badge reports quality only — never a token saving.
+
+def _on_pre_llm_call(**kw):
+    """Inject an optimized version of the user message as context.
+
+    Fires on every platform (desktop, gateway, CLI) once per turn. Skips
+    when the gateway already rewrote this turn (record present in
+    ``_session_rewrites``) to avoid double optimization, and skips short /
+    bypass / structured messages exactly like the gateway hook.
+    """
+    global _mode
+    with _mode_lock:
+        mode = _mode
+    if mode == "off":
+        return None
+    original = kw.get("user_message", "") or ""
+    if not isinstance(original, str) or not original.strip():
+        return None
+    stripped = original.strip()
+    session_id = kw.get("session_id", "") or ""
+    sid = session_id or "unknown"
+
+    # Gateway already rewrote this message this turn (pre_gateway_dispatch
+    # replaced the text, then the agent loop fired pre_llm_call with the
+    # rewritten text). Skip — rewriting the rewrite is pointless.
+    with _rewrite_lock:
+        if sid in _session_rewrites:
+            return None
+
+    if any(stripped.startswith(p) for p in BYPASS_PREFIXES):
+        return None
+
+    words = stripped.split()
+    if len(words) < 5 or len(stripped) < 35:
+        logger.info(
+            "prompt-optimizer: context skip — short message (%d words)",
+            len(words),
+        )
+        return None
+
+    if is_skill_invocation(stripped):
+        logger.info("prompt-optimizer: context skip — skill invocation")
+        return None
+
+    if is_structured_command(stripped):
+        logger.info("prompt-optimizer: context skip — structured command")
+        return None
+
+    if stripped.startswith("/"):
+        first_word = stripped.split(None, 1)[0]
+        if "/" not in first_word[1:]:
+            return None
+
+    model = kw.get("model", "") or ""
+    platform = kw.get("platform", "") or "desktop"
+
+    record = _run_optimizer_bridge(original, model, "")
+    if record is None:
+        return None
+
+    with _rewrite_lock:
+        _context_badges[sid] = (record.quality_before, record.quality_after)
+    _record(sid, platform, record.original, record.rewritten,
+            record.quality_before, record.quality_after,
+            record.token_delta_pct, record.model_profile,
+            model, mode="context", approved=True)
+    logger.info(
+        "prompt-optimizer: context rewrite %r → %r",
+        original[:60], record.rewritten[:60],
+    )
+    return {
+        "context": (
+            "Optimized version of the user's request — use THIS as the "
+            "authoritative request:\n\n"
+            f"{record.rewritten}"
+        )
+    }
+
+
 def _on_transform_llm_output(text="", response_text="", session_id="", **kw):
     """Append inline badge when a rewrite happened this turn."""
     if not session_id:
         return None
     with _rewrite_lock:
+        # Context-mode badge first: quality only — no token claim, because
+        # context injection sends the original AND the optimized prompt.
+        ctx_badge = _context_badges.pop(session_id, None)
         record = _session_rewrites.pop(session_id, None)
+    if ctx_badge is not None:
+        base = _coerce_text(response_text) or _coerce_text(text)
+        qb, qa = ctx_badge
+        badge = (
+            f"\n\n---\n"
+            f"Optimized (context) · quality {qb:.0f}\N{RIGHTWARDS ARROW}{qa:.0f} · "
+            f"/prompt-insights"
+        )
+        return base + badge
     if record is None:
         return None
     base = _coerce_text(response_text) or _coerce_text(text)
@@ -646,7 +761,15 @@ def register(ctx) -> None:
         logger.info(
             "prompt-optimizer: 'pre_user_message' hook unavailable in this "
             "Hermes build (upstream PR #29526 not merged) — CLI/TUI rewrite "
-            "disabled; gateway rewrite stays active via pre_gateway_dispatch"
+            "disabled; desktop rewrite active via pre_llm_call context "
+            "injection; gateway rewrite stays active via pre_gateway_dispatch"
+        )
+    if _hook_supported("pre_llm_call"):
+        ctx.register_hook("pre_llm_call", _on_pre_llm_call)
+    else:
+        logger.info(
+            "prompt-optimizer: 'pre_llm_call' hook unavailable — desktop "
+            "context rewrite disabled"
         )
     ctx.register_hook("transform_llm_output", _on_transform_llm_output)
     ctx.register_command(

--- a/__init__.py
+++ b/__init__.py
@@ -160,6 +160,12 @@ def _on_pre_gateway_dispatch(event=None, gateway=None, session_store=None, **kw)
     if any(stripped.startswith(p) for p in BYPASS_PREFIXES):
         return None
 
+    # Short prompts (< 5 words or < 35 chars) do not need LLM rewriting
+    words = stripped.split()
+    if len(words) < 5 or len(stripped) < 35:
+        logger.info("prompt-optimizer: skipped — short message (%d words)", len(words))
+        return None
+
     if is_skill_invocation(stripped):
         logger.info("prompt-optimizer: skipped — skill invocation")
         return None

--- a/engine.py
+++ b/engine.py
@@ -44,7 +44,12 @@ HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 PLUGIN_DIR = HERMES_HOME / "plugins" / "prompt-optimizer"
 METRICS_DB = PLUGIN_DIR / "metrics.db"
 
-OPTIMIZER_TIMEOUT_S = 3
+# Hard wall-clock cap for a rewrite LLM call, in seconds. The rewrite runs
+# on a worker thread and fails open ("no rewrite") when it expires, so this
+# never blocks the user's turn — but a value too low silently disables
+# rewriting on slow providers (real LLM round-trips routinely exceed 3s).
+# Tune with PROMPT_OPTIMIZER_TIMEOUT (seconds).
+OPTIMIZER_TIMEOUT_S = int(os.getenv("PROMPT_OPTIMIZER_TIMEOUT", "10"))
 
 BYPASS_PREFIXES = ("/quick", "*simple", "#basic")
 

--- a/engine.py
+++ b/engine.py
@@ -45,7 +45,6 @@ PLUGIN_DIR = HERMES_HOME / "plugins" / "prompt-optimizer"
 METRICS_DB = PLUGIN_DIR / "metrics.db"
 
 OPTIMIZER_TIMEOUT_S = 3
-OPTIMIZER_MODEL = "deepseek/deepseek-v4-flash"
 
 BYPASS_PREFIXES = ("/quick", "*simple", "#basic")
 

--- a/engine.py
+++ b/engine.py
@@ -45,7 +45,7 @@ PLUGIN_DIR = HERMES_HOME / "plugins" / "prompt-optimizer"
 METRICS_DB = PLUGIN_DIR / "metrics.db"
 
 OPTIMIZER_TIMEOUT_S = 3
-OPTIMIZER_MODEL = "deepseek-v4-flash"
+OPTIMIZER_MODEL = "deepseek/deepseek-v4-flash"
 
 BYPASS_PREFIXES = ("/quick", "*simple", "#basic")
 

--- a/engine.py
+++ b/engine.py
@@ -45,7 +45,7 @@ PLUGIN_DIR = HERMES_HOME / "plugins" / "prompt-optimizer"
 METRICS_DB = PLUGIN_DIR / "metrics.db"
 
 OPTIMIZER_TIMEOUT_S = 3
-OPTIMIZER_MODEL = "deepseek-flash"
+OPTIMIZER_MODEL = "deepseek-v4-flash"
 
 BYPASS_PREFIXES = ("/quick", "*simple", "#basic")
 

--- a/engine.py
+++ b/engine.py
@@ -44,8 +44,8 @@ HERMES_HOME = Path(os.getenv("HERMES_HOME", Path.home() / ".hermes"))
 PLUGIN_DIR = HERMES_HOME / "plugins" / "prompt-optimizer"
 METRICS_DB = PLUGIN_DIR / "metrics.db"
 
-OPTIMIZER_TIMEOUT_S = 30
-OPTIMIZER_MODEL = "deepseek-v4-flash"
+OPTIMIZER_TIMEOUT_S = 3
+OPTIMIZER_MODEL = "deepseek-flash"
 
 BYPASS_PREFIXES = ("/quick", "*simple", "#basic")
 

--- a/tests/test_prompt_optimizer_plugin.py
+++ b/tests/test_prompt_optimizer_plugin.py
@@ -361,6 +361,24 @@ def test_engine_resolve_model_profile_deepseek(engine):
     assert r_cap in ("reasoning", None)  # don't over-assert capability taxonomy
 
 
+def test_engine_timeout_default(engine):
+    # 3s was silently disabling rewrites on real LLM latency; default is 10s.
+    assert engine.OPTIMIZER_TIMEOUT_S == 10
+
+
+def test_engine_timeout_env_override(engine, monkeypatch):
+    import importlib
+
+    monkeypatch.setenv("PROMPT_OPTIMIZER_TIMEOUT", "7")
+    importlib.reload(engine)
+    try:
+        assert engine.OPTIMIZER_TIMEOUT_S == 7
+    finally:
+        monkeypatch.delenv("PROMPT_OPTIMIZER_TIMEOUT", raising=False)
+        importlib.reload(engine)
+        assert engine.OPTIMIZER_TIMEOUT_S == 10  # default restored
+
+
 # ---------------------------------------------------------------------------
 # engine — _run_optimizer rewrite path
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_optimizer_plugin.py
+++ b/tests/test_prompt_optimizer_plugin.py
@@ -1,0 +1,402 @@
+"""Tests for the prompt-optimizer plugin.
+
+Loads the plugin exactly the way the Hermes core does
+(``hermes_cli.plugins`` -> importlib spec from the plugin directory), so
+hook registration, bypass logic, and the engine behave as in production.
+
+Run with the Hermes venv from a directory OUTSIDE this plugin (pytest
+treats a rootdir containing ``__init__.py`` as a package, and this
+directory's hyphenated name is not a valid Python package identifier)::
+
+    cd /tmp && /path/to/hermes-agent/venv/bin/python -m pytest \\
+        ~/.hermes/plugins/prompt-optimizer/tests/test_prompt_optimizer_plugin.py -v
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+PLUGIN_DIR = Path(__file__).resolve().parent.parent
+_NS_PARENT = "hermes_plugins"
+
+
+def _load_plugin():
+    """Load the plugin module via the same importlib path the core uses."""
+    if _NS_PARENT not in sys.modules:
+        ns_pkg = types.ModuleType(_NS_PARENT)
+        ns_pkg.__path__ = []
+        ns_pkg.__package__ = _NS_PARENT
+        sys.modules[_NS_PARENT] = ns_pkg
+    module_name = f"{_NS_PARENT}.prompt_optimizer"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    init_file = PLUGIN_DIR / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        module_name, init_file, submodule_search_locations=[str(PLUGIN_DIR)]
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot create module spec for {init_file}")
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = module_name
+    module.__path__ = [str(PLUGIN_DIR)]
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="session")
+def po():
+    return _load_plugin()
+
+
+@pytest.fixture(scope="session")
+def engine():
+    return importlib.import_module(f"{_NS_PARENT}.prompt_optimizer.engine")
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class FakeCtx:
+    """Minimal stand-in for the plugin registration context."""
+
+    def __init__(self):
+        self.hooks = {}
+        self.commands = {}
+
+    def register_hook(self, name, callback):
+        self.hooks.setdefault(name, []).append(callback)
+
+    def register_command(self, name, handler, description="", args_hint=""):
+        self.commands[name] = handler
+
+
+class FakeEvent:
+    def __init__(self, text):
+        self.text = text
+        self.source = None
+
+
+class FakeSessionStore:
+    def __init__(self, session_id="test-session"):
+        self.session_id = session_id
+
+
+class FakePllm:
+    """Minimal stand-in for agent.plugin_llm.PluginLlm."""
+
+    def __init__(self, response_text=None):
+        self._response = response_text
+        self.calls = []
+
+    def complete(self, messages=None, **kwargs):
+        self.calls.append((messages, kwargs))
+        return types.SimpleNamespace(text=self._response)
+
+
+def _make_record(engine_mod, original, rewritten):
+    return engine_mod.RewriteRecord(
+        original=original,
+        rewritten=rewritten,
+        quality_before=40.0,
+        quality_after=90.0,
+        token_delta_pct=50.0,
+        model_profile="deepseek/general",
+    )
+
+
+LONG_PROMPT = (
+    "Please could you kindly write a comprehensive and very detailed analysis "
+    "of the entire financial market situation right now and compare it against "
+    "the previous trends we discussed earlier"
+)
+
+REWRITE_RESPONSE = (
+    "Write a financial market analysis.\n---SCORES---\n"
+    '{"clarity": 90, "specificity": 80, "terminology": 85, '
+    '"actionability": 88, "structure": 82}'
+)
+
+
+# ---------------------------------------------------------------------------
+# _hook_supported() — capability introspection
+# ---------------------------------------------------------------------------
+
+
+def test_hook_supported_known_hooks(po):
+    assert po._hook_supported("pre_gateway_dispatch") is True
+    assert po._hook_supported("transform_llm_output") is True
+    assert po._hook_supported("pre_llm_call") is True
+
+
+def test_hook_supported_pre_user_message_missing_on_current_core(po):
+    # Regression: this Hermes build has no pre_user_message hook (upstream
+    # PR #29526 not merged). The plugin must detect that instead of
+    # registering a callback that never fires.
+    assert po._hook_supported("pre_user_message") is False
+
+
+def test_hook_supported_optimistic_fallback(po, monkeypatch):
+    # If the core constant can't be imported, fall back to optimistic True
+    # so plugin load can never break on a renamed/removed constant.
+    import builtins
+
+    real_import = builtins.__import__
+
+    def raiser(name, *args, **kwargs):
+        if name == "hermes_cli.plugins":
+            raise ImportError("simulated missing module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", raiser)
+    assert po._hook_supported("anything") is True
+
+
+# ---------------------------------------------------------------------------
+# register() — hook + command registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_hooks_and_commands(po):
+    ctx = FakeCtx()
+    po.register(ctx)
+    assert "pre_gateway_dispatch" in ctx.hooks
+    assert "transform_llm_output" in ctx.hooks
+    # Unsupported on this build — must NOT be registered (the fix under test).
+    assert "pre_user_message" not in ctx.hooks
+    for cmd in (
+        "prompt-optimizer",
+        "prompt-insights",
+        "prompt-compare",
+        "prompt-suggestions",
+        "prompt-analytics",
+        "prompt-stats",
+    ):
+        assert cmd in ctx.commands, f"missing slash command: {cmd}"
+
+
+def test_register_pre_user_message_when_supported(po, monkeypatch):
+    # Forward-compatibility: on a core with the hook, registration happens
+    # exactly as before.
+    monkeypatch.setattr(po, "_hook_supported", lambda name: True)
+    ctx = FakeCtx()
+    po.register(ctx)
+    assert "pre_user_message" in ctx.hooks
+
+
+# ---------------------------------------------------------------------------
+# _on_pre_gateway_dispatch — bypasses
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def gateway(po):
+    """Reset the plugin's global mode/ctx between tests."""
+    prev_mode = po._mode
+    prev_ctx = po._ctx
+    po._mode = "auto"
+    po._ctx = None
+    yield
+    po._mode = prev_mode
+    po._ctx = prev_ctx
+
+
+def test_gateway_mode_off_passthrough(po, gateway):
+    po._mode = "off"
+    assert po._on_pre_gateway_dispatch(event=FakeEvent(LONG_PROMPT)) is None
+
+
+def test_gateway_none_event(po, gateway):
+    assert po._on_pre_gateway_dispatch(event=None) is None
+
+
+def test_gateway_empty_text(po, gateway):
+    assert po._on_pre_gateway_dispatch(event=FakeEvent("   ")) is None
+
+
+def test_gateway_bypass_prefix(po, gateway):
+    event = FakeEvent("/quick " + LONG_PROMPT)
+    assert po._on_pre_gateway_dispatch(event=event) is None
+
+
+def test_gateway_short_message_fast_path(po, gateway):
+    # perf: < 5 words or < 35 chars skips the LLM entirely.
+    assert po._on_pre_gateway_dispatch(event=FakeEvent("Hi")) is None
+    assert po._on_pre_gateway_dispatch(event=FakeEvent("short prompt here")) is None
+
+
+def test_gateway_slash_command(po, gateway):
+    assert po._on_pre_gateway_dispatch(event=FakeEvent("/help")) is None
+    assert po._on_pre_gateway_dispatch(event=FakeEvent("/prompt-stats")) is None
+
+
+def test_gateway_skill_invocation(po, gateway):
+    text = (
+        "[IMPORTANT: The user has invoked the 'web_search' skill. Please use it "
+        "thoroughly for this research task and report back with full citations.]"
+    )
+    assert po._on_pre_gateway_dispatch(event=FakeEvent(text)) is None
+
+
+def test_gateway_structured_command_fenced_code(po, gateway):
+    text = (
+        "Please execute this task exactly as specified:\n"
+        "```json\n{\"task\": \"delegate\", \"payload\": {...}}\n```\n"
+        "and then report what happened with the complete output please"
+    )
+    assert po._on_pre_gateway_dispatch(event=FakeEvent(text)) is None
+
+
+def test_gateway_structured_command_verb(po, gateway):
+    text = (
+        "delegate_task: build me a full authentication system with login, "
+        "logout, password reset, email verification, and role-based access control"
+    )
+    assert po._on_pre_gateway_dispatch(event=FakeEvent(text)) is None
+
+
+def test_gateway_file_path_is_not_slash_command(po, gateway):
+    # A path-like first word must NOT be treated as a slash command. The
+    # prompt proceeds to the optimizer; with no _ctx the bridge bypasses
+    # (returns None) instead of raising.
+    text = (
+        "/Users/developer/code/project/main.py please review this file "
+        "carefully and tell me what you think about its overall structure"
+    )
+    assert po._on_pre_gateway_dispatch(event=FakeEvent(text)) is None
+
+
+# ---------------------------------------------------------------------------
+# _on_pre_gateway_dispatch — rewrite behaviour (auto + interactive)
+# ---------------------------------------------------------------------------
+
+
+def test_gateway_auto_rewrite(po, engine, gateway, monkeypatch):
+    rec = _make_record(engine, LONG_PROMPT, "Write a financial market analysis.")
+    monkeypatch.setattr(po, "_run_optimizer_bridge", lambda *a, **k: rec)
+    result = po._on_pre_gateway_dispatch(event=FakeEvent(LONG_PROMPT))
+    assert result == {"action": "rewrite", "text": rec.rewritten}
+
+
+def test_gateway_auto_no_rewrite(po, gateway, monkeypatch):
+    monkeypatch.setattr(po, "_run_optimizer_bridge", lambda *a, **k: None)
+    assert po._on_pre_gateway_dispatch(event=FakeEvent(LONG_PROMPT)) is None
+
+
+def test_gateway_interactive_shows_diff(po, engine, gateway, monkeypatch):
+    rec = _make_record(engine, LONG_PROMPT, "Write a financial market analysis.")
+    po._mode = "interactive"
+    monkeypatch.setattr(po, "_run_optimizer_bridge", lambda *a, **k: rec)
+    monkeypatch.setattr(po, "_send_diff_via_gateway", lambda *a, **k: None)
+    result = po._on_pre_gateway_dispatch(
+        event=FakeEvent(LONG_PROMPT), session_store=FakeSessionStore("s1")
+    )
+    assert result == {"action": "skip", "reason": "interactive-diff-shown"}
+
+
+def test_gateway_interactive_accept(po, engine, gateway, monkeypatch):
+    rec = _make_record(engine, LONG_PROMPT, "Write a financial market analysis.")
+    po._mode = "interactive"
+    monkeypatch.setattr(po, "_run_optimizer_bridge", lambda *a, **k: rec)
+    monkeypatch.setattr(po, "_send_diff_via_gateway", lambda *a, **k: None)
+    # First call queues the pending approval (short text still needs to be
+    # the *same* session, so use the long prompt to reach the queue).
+    first = po._on_pre_gateway_dispatch(
+        event=FakeEvent(LONG_PROMPT), session_store=FakeSessionStore("s1")
+    )
+    assert first == {"action": "skip", "reason": "interactive-diff-shown"}
+    # User approves with "y" on the same session.
+    second = po._on_pre_gateway_dispatch(
+        event=FakeEvent("y"), session_store=FakeSessionStore("s1")
+    )
+    assert second == {"action": "rewrite", "text": rec.rewritten}
+
+
+# ---------------------------------------------------------------------------
+# engine — helpers
+# ---------------------------------------------------------------------------
+
+
+def test_engine_is_structured_command(engine, monkeypatch):
+    assert engine.is_structured_command("delegate_task: run the pipeline") is True
+    assert engine.is_structured_command("delegate: something") is True
+    assert engine.is_structured_command("```python\nprint(1)\n```") is True
+    assert engine.is_structured_command("Build me a thing please") is False
+    monkeypatch.setenv("PROMPT_OPTIMIZER_BYPASS_VERBS", "orchestrate")
+    assert engine.is_structured_command("orchestrate: run the pipeline") is True
+
+
+def test_engine_is_skill_invocation(engine):
+    marker = "[IMPORTANT: The user has invoked the"
+    assert engine.is_skill_invocation(marker + " 'x' skill.]") is True
+    assert engine.is_skill_invocation("ordinary user prose") is False
+
+
+def test_engine_score_prompt_heuristic(engine):
+    score, tokens = engine._score_prompt_heuristic(LONG_PROMPT)
+    assert isinstance(score, float) and 0 <= score <= 100
+    assert isinstance(tokens, int) and tokens >= 1
+    assert engine._score_prompt_heuristic("") == (0.0, 0)
+    terse = engine._score_prompt_heuristic("hi there")[0]
+    assert score > terse
+
+
+def test_engine_resolve_model_profile_deepseek(engine):
+    family, capability = engine.resolve_model_profile("deepseek/deepseek-v4-flash")
+    assert family == "deepseek"
+    # A pure reasoning variant should resolve the reasoning capability.
+    r_family, r_cap = engine.resolve_model_profile("deepseek/deepseek-r1")
+    assert r_cap in ("reasoning", None)  # don't over-assert capability taxonomy
+
+
+# ---------------------------------------------------------------------------
+# engine — _run_optimizer rewrite path
+# ---------------------------------------------------------------------------
+
+
+def test_engine_rewrite_with_fake_llm(engine):
+    pllm = FakePllm(response_text=REWRITE_RESPONSE)
+    record = engine._run_optimizer(LONG_PROMPT, "deepseek/deepseek-v4-flash", "kilocode", pllm)
+    assert record is not None
+    assert "financial market analysis" in record.rewritten
+    assert record.original == LONG_PROMPT
+    assert record.model_profile.startswith("deepseek")
+    assert record.quality_after == pytest.approx((90 + 80 + 85 + 88 + 82) / 5)
+    assert pllm.calls and pllm.calls[0][0] is not None  # messages were sent
+
+
+def test_engine_rewrite_none_llm(engine):
+    # No host LLM (e.g. _ctx unset) -> fail open with no rewrite.
+    assert engine._run_optimizer(LONG_PROMPT, "", "", None) is None
+
+
+def test_engine_parse_rewrite_response(engine):
+    parsed = engine._parse_rewrite_response(REWRITE_RESPONSE, LONG_PROMPT)
+    assert parsed is not None
+    rewritten, scores = parsed
+    assert "financial market analysis" in rewritten
+    assert set(scores) >= {"clarity", "specificity", "terminology", "actionability", "structure"}
+    # Missing separator -> rejected.
+    assert engine._parse_rewrite_response("no separator here", LONG_PROMPT) is None
+    # Identity rewrite -> rejected.
+    assert engine._parse_rewrite_response(LONG_PROMPT + "\n---SCORES---\n{}", LONG_PROMPT) is None
+
+
+def test_engine_extract_composite(engine):
+    good = {"clarity": 90, "specificity": 80, "terminology": 85,
+            "actionability": 88, "structure": 82}
+    assert engine._extract_composite(good) == pytest.approx(85.0)
+    # Missing dimensions -> -1.0 sentinel (heuristic fallback in caller).
+    assert engine._extract_composite({"clarity": 50}) == -1.0
+    # Out-of-range values -> -1.0 sentinel.
+    bad = dict(good, clarity=101)
+    assert engine._extract_composite(bad) == -1.0

--- a/tests/test_prompt_optimizer_plugin.py
+++ b/tests/test_prompt_optimizer_plugin.py
@@ -169,6 +169,7 @@ def test_register_hooks_and_commands(po):
     ctx = FakeCtx()
     po.register(ctx)
     assert "pre_gateway_dispatch" in ctx.hooks
+    assert "pre_llm_call" in ctx.hooks
     assert "transform_llm_output" in ctx.hooks
     # Unsupported on this build — must NOT be registered (the fix under test).
     assert "pre_user_message" not in ctx.hooks
@@ -206,11 +207,13 @@ def gateway(po):
     po._ctx = None
     po._pending_approvals.clear()
     po._session_rewrites.clear()
+    po._context_badges.clear()
     yield
     po._mode = prev_mode
     po._ctx = prev_ctx
     po._pending_approvals.clear()
     po._session_rewrites.clear()
+    po._context_badges.clear()
 
 
 def test_gateway_mode_off_passthrough(po, gateway):
@@ -322,6 +325,100 @@ def test_gateway_interactive_accept(po, engine, gateway, monkeypatch):
         event=FakeEvent("y"), session_store=FakeSessionStore("s1")
     )
     assert second == {"action": "rewrite", "text": rec.rewritten}
+
+
+# ---------------------------------------------------------------------------
+# _on_pre_llm_call — desktop context-injection path
+# ---------------------------------------------------------------------------
+
+
+def test_pre_llm_call_mode_off(po, gateway):
+    po._mode = "off"
+    assert po._on_pre_llm_call(user_message=LONG_PROMPT, session_id="s1") is None
+
+
+def test_pre_llm_call_empty(po, gateway):
+    assert po._on_pre_llm_call(user_message="   ") is None
+    assert po._on_pre_llm_call() is None
+
+
+def test_pre_llm_call_short_message(po, gateway):
+    assert po._on_pre_llm_call(user_message="Hi there", session_id="s1") is None
+
+
+def test_pre_llm_call_bypass_prefix(po, gateway):
+    assert po._on_pre_llm_call(user_message="/quick " + LONG_PROMPT) is None
+
+
+def test_pre_llm_call_skill_invocation(po, gateway):
+    text = (
+        "[IMPORTANT: The user has invoked the 'web_search' skill. Please use "
+        "it thoroughly for this research task and report back with citations.]"
+    )
+    assert po._on_pre_llm_call(user_message=text, session_id="s1") is None
+
+
+def test_pre_llm_call_slash_command(po, gateway):
+    assert po._on_pre_llm_call(user_message="/prompt-stats", session_id="s1") is None
+
+
+def test_pre_llm_call_skips_when_gateway_already_rewrote(po, engine, gateway):
+    # pre_gateway_dispatch already replaced the text and stored the record;
+    # pre_llm_call must NOT rewrite the rewrite.
+    rec = _make_record(engine, LONG_PROMPT, "Write a financial market analysis.")
+    with po._rewrite_lock:
+        po._session_rewrites["s1"] = rec
+    assert po._on_pre_llm_call(user_message="Write a financial market analysis.",
+                               session_id="s1") is None
+
+
+def test_pre_llm_call_context_injection(po, engine, gateway, monkeypatch):
+    rec = _make_record(engine, LONG_PROMPT, "Write a financial market analysis.")
+    monkeypatch.setattr(po, "_run_optimizer_bridge", lambda *a, **k: rec)
+    result = po._on_pre_llm_call(
+        user_message=LONG_PROMPT, session_id="s1", model="deepseek/deepseek-v4-flash",
+        platform="desktop",
+    )
+    assert isinstance(result, dict)
+    assert "context" in result
+    assert "Write a financial market analysis." in result["context"]
+    assert "authoritative request" in result["context"]
+    # Quality-only badge stashed for transform_llm_output, no token claim.
+    with po._rewrite_lock:
+        assert po._context_badges.get("s1") == (40.0, 90.0)
+        assert "s1" not in po._session_rewrites
+
+
+def test_pre_llm_call_no_rewrite(po, gateway, monkeypatch):
+    monkeypatch.setattr(po, "_run_optimizer_bridge", lambda *a, **k: None)
+    assert po._on_pre_llm_call(user_message=LONG_PROMPT, session_id="s1") is None
+
+
+def test_pre_llm_call_badge_quality_only(po, engine, gateway, monkeypatch):
+    # Context badge renders quality but never a token-savings claim.
+    with po._rewrite_lock:
+        po._context_badges["s1"] = (40.0, 90.0)
+    out = po._on_transform_llm_output(response_text="Done.", session_id="s1")
+    assert out is not None
+    assert "Optimized (context)" in out
+    assert "40" in out and "90" in out
+    assert "% tokens" not in out
+
+
+def test_transform_llm_output_context_then_rewrite_badge(po, engine, gateway):
+    # transform_llm_output pops the context badge first; a stale rewrite
+    # record in the same session must not double-badge.
+    with po._rewrite_lock:
+        po._context_badges["s1"] = (40.0, 90.0)
+        po._session_rewrites["s1"] = _make_record(
+            engine, LONG_PROMPT, "Write a financial market analysis."
+        )
+    out = po._on_transform_llm_output(response_text="Done.", session_id="s1")
+    assert "Optimized (context)" in out
+    assert "% tokens" not in out
+    with po._rewrite_lock:
+        assert "s1" not in po._session_rewrites
+        assert "s1" not in po._context_badges
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_optimizer_plugin.py
+++ b/tests/test_prompt_optimizer_plugin.py
@@ -56,8 +56,26 @@ def po():
 
 
 @pytest.fixture(scope="session")
-def engine():
+def engine(po):
+    # Depends on po: the plugin loader creates the hermes_plugins namespace
+    # package in sys.modules, which this import requires.
     return importlib.import_module(f"{_NS_PARENT}.prompt_optimizer.engine")
+
+
+@pytest.fixture(autouse=True)
+def _temp_metrics_db(engine, tmp_path, monkeypatch):
+    """Isolate all metrics writes to a temp DB.
+
+    The plugin's engine reads ``METRICS_DB`` at call time via ``_db()`` ->
+    ``_ensure_db()``, so monkeypatching the module constant redirects every
+    ``_record()`` (rewrite metrics) and ``_ensure_db()`` (register()) call
+    made by the tests. Without this, running pytest writes fake rewrite rows
+    into the production ~/.hermes/plugins/prompt-optimizer/metrics.db and
+    inflates /prompt-insights stats (12 such rows were found and deleted).
+    """
+    temp_db = tmp_path / "metrics.db"
+    monkeypatch.setattr(engine, "METRICS_DB", temp_db)
+    yield
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_optimizer_plugin.py
+++ b/tests/test_prompt_optimizer_plugin.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
-import json
 import sys
 import types
 from pathlib import Path
@@ -200,14 +199,18 @@ def test_register_pre_user_message_when_supported(po, monkeypatch):
 
 @pytest.fixture
 def gateway(po):
-    """Reset the plugin's global mode/ctx between tests."""
+    """Reset the plugin's global mode/ctx/pending state between tests."""
     prev_mode = po._mode
     prev_ctx = po._ctx
     po._mode = "auto"
     po._ctx = None
+    po._pending_approvals.clear()
+    po._session_rewrites.clear()
     yield
     po._mode = prev_mode
     po._ctx = prev_ctx
+    po._pending_approvals.clear()
+    po._session_rewrites.clear()
 
 
 def test_gateway_mode_off_passthrough(po, gateway):


### PR DESCRIPTION
## What

Adds a **desktop rewrite path** for the prompt optimizer on Hermes builds that lack the `pre_user_message` hook (upstream NousResearch/hermes-agent PR #29526 was **closed unmerged** — the hook is not available at Hermes v0.20.0, so desktop/CLI messages were never optimized; only the Telegram gateway path worked).

Uses the `pre_llm_call` hook (valid in every Hermes v0.20.0 `VALID_HOOKS`) to inject the optimized prompt as **context** into the API-bound user message:

- Fires once per turn on **every platform** (desktop, gateway, CLI)
- Same bypass guards as the gateway hook: short messages (<5 words / <35 chars), `/quick` `*simple` `#basic` prefixes, skill invocations, structured commands, slash commands
- **Double-rewrite guard**: skips when `pre_gateway_dispatch` already rewrote this turn — never rewrites the rewrite
- Context is composed into `api_content` only (never persisted in history), so no history pollution
- Metrics recorded with `mode="context"` — honest: context injection sends original + optimized, so tokens go **up** slightly
- Badge renders `Optimized (context) · quality X→Y` with **no token-savings claim** (it didn't save tokens)

## Bundled commits (branch `fix/conditional-pre-user-message-hook`)

| Commit | Change |
|---|---|
| `196d93c` | fix: guard `pre_user_message` hook registration (introspect `VALID_HOOKS`, degrade gracefully on builds without the hook — removes the "unknown hook" WARNING) |
| `9e63156` | refactor: remove dead `OPTIMIZER_MODEL` constant (unreferenced, stale model ID) |
| `cc1e02f` | fix: interactive approval replies (`y`/`n`) swallowed by short-message fast-path |
| `c0fc0b0` | test: drop unused json import; reset pending state in gateway fixture |
| `11c5180` | perf: make rewrite timeout env-tunable (`PROMPT_OPTIMIZER_TIMEOUT`), default 10s (was 3s — silently disabled rewrites on real LLM latency) |
| `3e68df4` | **feat: desktop rewrite via `pre_llm_call` context injection** (this PR's headline) |
| `0db0c0e` | test: isolate metrics writes to a temp DB (tests were writing fake rows into production `metrics.db`, inflating `/prompt-insights`; 12 polluted rows found + deleted) |

## Verification

- 40/40 tests pass (9 new for the `pre_llm_call` path incl. badge honesty + double-rewrite skip)
- Smoke-tested with the core's plugin loader replication — hooks register cleanly, no unknown-hook WARNINGs after restart
- Production `metrics.db` verified untouched by test runs

## Notes

- Test suite must run from a directory **outside** the plugin dir (`cd /tmp && <venv>/python -m pytest ~/.hermes/plugins/prompt-optimizer/tests/...`) — the hyphenated directory name is not a valid Python package identifier and pytest's package collector imports the root `__init__.py` as a bare module otherwise.
- The `pre_user_message` path remains registered **when the hook exists** (future Hermes builds); this PR is the working fallback for v0.20.0.
